### PR TITLE
 2단계 - 지뢰 찾기(지뢰 개수)

### DIFF
--- a/src/main/kotlin/minesweeper/Application.kt
+++ b/src/main/kotlin/minesweeper/Application.kt
@@ -3,5 +3,5 @@ package minesweeper
 import minesweeper.controller.MineSweeperController
 
 fun main() {
-    MineSweeperController().play()
+    MineSweeperController.play()
 }

--- a/src/main/kotlin/minesweeper/controller/MineSweeperController.kt
+++ b/src/main/kotlin/minesweeper/controller/MineSweeperController.kt
@@ -4,7 +4,7 @@ import minesweeper.model.Board
 import minesweeper.view.InputView
 import minesweeper.view.OutputView
 
-class MineSweeperController {
+object MineSweeperController {
 
     private val inputView = InputView()
     private val outputView = OutputView()

--- a/src/main/kotlin/minesweeper/controller/MineSweeperController.kt
+++ b/src/main/kotlin/minesweeper/controller/MineSweeperController.kt
@@ -1,6 +1,10 @@
 package minesweeper.controller
 
 import minesweeper.model.Board
+import minesweeper.model.Height
+import minesweeper.model.MineCount
+import minesweeper.model.Position
+import minesweeper.model.Width
 import minesweeper.view.InputView
 import minesweeper.view.OutputView
 
@@ -14,7 +18,17 @@ object MineSweeperController {
         val width = inputView.getWidth()
         val mineCount = inputView.getMineCount()
 
-        val board = Board.shuffled(width, height, mineCount)
+        val board = createBoard(width, height, mineCount)
         outputView.showGamePlay(board)
+    }
+
+    private fun createBoard(width: Width, height: Height, mineCount: MineCount): Board {
+        val size = width.value * height.value
+        val positions = Position.list(width, height)
+            .shuffled()
+            .take(mineCount.value.coerceAtMost(size))
+
+        return positions
+            .fold(Board.create(width, height)) { acc, position -> acc.mine(position) }
     }
 }

--- a/src/main/kotlin/minesweeper/model/Board.kt
+++ b/src/main/kotlin/minesweeper/model/Board.kt
@@ -18,7 +18,7 @@ class Board(val cells: Cells) {
                 return EMPTY
             }
             val positions = Position.list(width, height)
-            val cells: List<Cell> = positions.map { position -> Cell.Blank(position) }
+            val cells: List<Cell> = positions.map { position -> Cell.Zero(position) }
             return Board(Cells(cells))
         }
 
@@ -36,7 +36,7 @@ class Board(val cells: Cells) {
                 if (index < mineCount.value) {
                     Cell.Mine(position)
                 } else {
-                    Cell.Blank(position)
+                    Cell.Zero(position)
                 }
             }
             return Board(Cells(cells))

--- a/src/main/kotlin/minesweeper/model/Board.kt
+++ b/src/main/kotlin/minesweeper/model/Board.kt
@@ -6,8 +6,6 @@ class Board(val cells: Cells) {
 
     val height: Height = Height.valueOf(cells.maxRowOrNull()?.value)
 
-    val mineCount: MineCount = cells.mineCount()
-
     fun mine(position: Position): Board = cells
         .mine(position)
         .incrementAll(position.asDirections())
@@ -22,26 +20,6 @@ class Board(val cells: Cells) {
             }
             val positions = Position.list(width, height)
             val cells: List<Cell> = positions.map { position -> Cell.Zero(position) }
-            return Board(Cells(cells))
-        }
-
-        fun shuffled(
-            width: Width,
-            height: Height,
-            mineCount: MineCount
-        ): Board {
-            val size = width.value * height.value
-            if (size == 0) return EMPTY
-            require(size >= mineCount.value) { "지뢰의 개수는 보드 크기보다 많을 수 없음" }
-
-            val positions = Position.list(width, height).shuffled()
-            val cells = positions.mapIndexed { index, position ->
-                if (index < mineCount.value) {
-                    Cell.Mine(position)
-                } else {
-                    Cell.Zero(position)
-                }
-            }
             return Board(Cells(cells))
         }
     }

--- a/src/main/kotlin/minesweeper/model/Board.kt
+++ b/src/main/kotlin/minesweeper/model/Board.kt
@@ -11,10 +11,19 @@ class Board(val cells: Cells) {
     companion object {
         val EMPTY = Board(Cells.EMPTY)
 
+        fun create(width: Width, height: Height): Board {
+            if (width == Width.ZERO || height == Height.ZERO) {
+                return EMPTY
+            }
+            val positions = Position.list(width, height)
+            val cells: List<Cell> = positions.map { position -> Cell.Blank(position) }
+            return Board(Cells(cells))
+        }
+
         fun shuffled(
             width: Width,
             height: Height,
-            mineCount: MineCount = MineCount.ZERO
+            mineCount: MineCount
         ): Board {
             val size = width.value * height.value
             if (size == 0) return EMPTY

--- a/src/main/kotlin/minesweeper/model/Board.kt
+++ b/src/main/kotlin/minesweeper/model/Board.kt
@@ -8,7 +8,10 @@ class Board(val cells: Cells) {
 
     val mineCount: MineCount = cells.mineCount()
 
-    fun mine(position: Position): Board = Board(cells.mine(position))
+    fun mine(position: Position): Board = cells
+        .mine(position)
+        .incrementAll(position.asDirections())
+        .let { Board(it) }
 
     companion object {
         val EMPTY = Board(Cells.EMPTY)

--- a/src/main/kotlin/minesweeper/model/Board.kt
+++ b/src/main/kotlin/minesweeper/model/Board.kt
@@ -8,6 +8,8 @@ class Board(val cells: Cells) {
 
     val mineCount: MineCount = cells.mineCount()
 
+    fun mine(position: Position): Board = Board(cells.mine(position))
+
     companion object {
         val EMPTY = Board(Cells.EMPTY)
 

--- a/src/main/kotlin/minesweeper/model/Cell.kt
+++ b/src/main/kotlin/minesweeper/model/Cell.kt
@@ -12,7 +12,7 @@ sealed class Cell {
         else -> Mine(position)
     }
 
-    data class Blank(override val position: Position) : Cell()
+    data class Zero(override val position: Position) : Cell()
 
     data class Mine(override val position: Position) : Cell()
 }

--- a/src/main/kotlin/minesweeper/model/Cell.kt
+++ b/src/main/kotlin/minesweeper/model/Cell.kt
@@ -12,6 +12,11 @@ sealed class Cell {
         else -> Mine(position)
     }
 
+    data class Number(
+        val adjustMineCount: MineCount,
+        override val position: Position
+    ) : Cell()
+
     data class Zero(override val position: Position) : Cell()
 
     data class Mine(override val position: Position) : Cell()

--- a/src/main/kotlin/minesweeper/model/Cell.kt
+++ b/src/main/kotlin/minesweeper/model/Cell.kt
@@ -8,13 +8,7 @@ sealed class Cell {
 
     val column: Column get() = position.column
 
-    data class Blank(override val position: Position) : Cell() {
+    data class Blank(override val position: Position) : Cell()
 
-        constructor(row: Row, column: Column) : this(Position(row, column))
-    }
-
-    data class Mine(override val position: Position) : Cell() {
-
-        constructor(row: Row, column: Column) : this(Position(row, column))
-    }
+    data class Mine(override val position: Position) : Cell()
 }

--- a/src/main/kotlin/minesweeper/model/Cell.kt
+++ b/src/main/kotlin/minesweeper/model/Cell.kt
@@ -15,7 +15,14 @@ sealed class Cell {
     data class Number(
         val adjustMineCount: MineCount,
         override val position: Position
-    ) : Cell()
+    ) : Cell() {
+
+        init {
+            require(adjustMineCount != MineCount.ZERO)
+        }
+
+        fun increment(): Cell = copy(adjustMineCount = adjustMineCount.increment())
+    }
 
     data class Zero(override val position: Position) : Cell()
 

--- a/src/main/kotlin/minesweeper/model/Cell.kt
+++ b/src/main/kotlin/minesweeper/model/Cell.kt
@@ -12,6 +12,8 @@ sealed class Cell {
         else -> Mine(position)
     }
 
+    abstract fun increment(): Cell
+
     data class Number(
         val adjustMineCount: MineCount,
         override val position: Position
@@ -21,10 +23,16 @@ sealed class Cell {
             require(adjustMineCount != MineCount.ZERO)
         }
 
-        fun increment(): Cell = copy(adjustMineCount = adjustMineCount.increment())
+        override fun increment(): Cell = copy(adjustMineCount = adjustMineCount.increment())
     }
 
-    data class Zero(override val position: Position) : Cell()
+    data class Zero(override val position: Position) : Cell() {
 
-    data class Mine(override val position: Position) : Cell()
+        override fun increment(): Cell = Number(MineCount.valueOf(1), position)
+    }
+
+    data class Mine(override val position: Position) : Cell() {
+
+        override fun increment(): Cell = this
+    }
 }

--- a/src/main/kotlin/minesweeper/model/Cell.kt
+++ b/src/main/kotlin/minesweeper/model/Cell.kt
@@ -5,8 +5,12 @@ sealed class Cell {
     abstract val position: Position
 
     val row: Row get() = position.row
-
     val column: Column get() = position.column
+
+    fun mine(): Cell = when (this) {
+        is Mine -> this
+        else -> Mine(position)
+    }
 
     data class Blank(override val position: Position) : Cell()
 

--- a/src/main/kotlin/minesweeper/model/Cells.kt
+++ b/src/main/kotlin/minesweeper/model/Cells.kt
@@ -11,13 +11,27 @@ value class Cells(private val cells: List<Cell>) {
 
     operator fun get(position: Position): Cell? = cells.find { it.row == position.row && it.column == position.column }
 
-    fun mine(position: Position): Cells = cells.map { cell ->
-        if (cell.position == position) {
-            cell.mine()
-        } else {
-            cell
-        }
-    }.let(::Cells)
+    fun mine(position: Position): Cells = update(
+        predicate = { it.position == position },
+        transform = { it.mine() }
+    )
+
+    fun increment(position: Position): Cells = update(
+        predicate = { it.position == position },
+        transform = { it.increment() }
+    )
+
+    fun incrementAll(positions: List<Position>): Cells = update(
+        predicate = { it.position in positions },
+        transform = { it.increment() }
+    )
+
+    private fun update(
+        predicate: (Cell) -> Boolean,
+        transform: (Cell) -> (Cell)
+    ): Cells = cells
+        .map { cell -> if (predicate(cell)) transform(cell) else cell }
+        .let(::Cells)
 
     companion object {
         val EMPTY: Cells = Cells(emptyList())

--- a/src/main/kotlin/minesweeper/model/Cells.kt
+++ b/src/main/kotlin/minesweeper/model/Cells.kt
@@ -7,8 +7,6 @@ value class Cells(private val cells: List<Cell>) {
 
     fun maxRowOrNull(): Row? = cells.maxByOrNull { it.row.value }?.row
 
-    fun mineCount(): MineCount = MineCount.valueOf(cells.count { it is Cell.Mine })
-
     operator fun get(position: Position): Cell? = cells.find { it.row == position.row && it.column == position.column }
 
     fun mine(position: Position): Cells = update(

--- a/src/main/kotlin/minesweeper/model/Cells.kt
+++ b/src/main/kotlin/minesweeper/model/Cells.kt
@@ -11,6 +11,14 @@ value class Cells(private val cells: List<Cell>) {
 
     operator fun get(position: Position): Cell? = cells.find { it.row == position.row && it.column == position.column }
 
+    fun mine(position: Position): Cells = cells.map { cell ->
+        if (cell.position == position) {
+            cell.mine()
+        } else {
+            cell
+        }
+    }.let(::Cells)
+
     companion object {
         val EMPTY: Cells = Cells(emptyList())
     }

--- a/src/main/kotlin/minesweeper/model/Column.kt
+++ b/src/main/kotlin/minesweeper/model/Column.kt
@@ -3,6 +3,10 @@ package minesweeper.model
 @JvmInline
 value class Column(val value: Int) {
 
+    fun increment(): Column = Column(value + 1)
+
+    fun decrement(): Column = Column((value - 1).coerceAtLeast(1))
+
     init {
         require(value > 0)
     }

--- a/src/main/kotlin/minesweeper/model/MineCount.kt
+++ b/src/main/kotlin/minesweeper/model/MineCount.kt
@@ -3,6 +3,8 @@ package minesweeper.model
 @JvmInline
 value class MineCount private constructor(val value: Int) {
 
+    fun increment(): MineCount = MineCount(value.inc())
+
     companion object {
         val ZERO: MineCount = MineCount(0)
 

--- a/src/main/kotlin/minesweeper/model/Position.kt
+++ b/src/main/kotlin/minesweeper/model/Position.kt
@@ -2,6 +2,22 @@ package minesweeper.model
 
 data class Position(val row: Row, val column: Column) {
 
+    fun top(): Position = copy(row = row.decrement())
+
+    fun topLeft(): Position = Position(row = row.decrement(), column = column.decrement())
+
+    fun topRight(): Position = Position(row = row.decrement(), column = column.increment())
+
+    fun left(): Position = copy(column = column.decrement())
+
+    fun right(): Position = copy(column = column.increment())
+
+    fun bottom(): Position = copy(row = row.increment())
+
+    fun bottomLeft(): Position = Position(row = row.increment(), column = column.decrement())
+
+    fun bottomRight(): Position = Position(row = row.increment(), column = column.increment())
+
     companion object {
         fun list(width: Width, height: Height): List<Position> = List(width.value * height.value) { index ->
             val row = (index / width.value) + 1

--- a/src/main/kotlin/minesweeper/model/Position.kt
+++ b/src/main/kotlin/minesweeper/model/Position.kt
@@ -18,6 +18,17 @@ data class Position(val row: Row, val column: Column) {
 
     fun bottomRight(): Position = Position(row = row.increment(), column = column.increment())
 
+    fun asDirections(): List<Position> = listOf(
+        top(),
+        topRight(),
+        topLeft(),
+        right(),
+        left(),
+        bottom(),
+        bottomRight(),
+        bottomLeft()
+    )
+
     companion object {
         fun list(width: Width, height: Height): List<Position> = List(width.value * height.value) { index ->
             val row = (index / width.value) + 1

--- a/src/main/kotlin/minesweeper/model/Row.kt
+++ b/src/main/kotlin/minesweeper/model/Row.kt
@@ -3,6 +3,10 @@ package minesweeper.model
 @JvmInline
 value class Row(val value: Int) {
 
+    fun increment(): Row = Row(value + 1)
+
+    fun decrement(): Row = Row((value - 1).coerceAtLeast(1))
+
     init {
         require(value > 0)
     }

--- a/src/main/kotlin/minesweeper/view/OutputView.kt
+++ b/src/main/kotlin/minesweeper/view/OutputView.kt
@@ -6,7 +6,7 @@ import minesweeper.model.Height
 import minesweeper.model.Position
 import minesweeper.model.Row
 import minesweeper.model.Width
-import minesweeper.view.res.getString
+import minesweeper.view.resource.getString
 
 class OutputView {
 
@@ -24,11 +24,9 @@ class OutputView {
         println()
     }
 
-    private fun onRow(height: Height, block: (Row) -> Unit) {
-        repeat(height.value) { row -> block(Row(row + 1)) }
-    }
+    private fun onRow(height: Height, block: (Row) -> Unit) =
+        repeat(height.value) { index -> block(Row(index + 1)) }
 
-    private fun onColumn(width: Width, block: (Column) -> Unit) {
-        repeat(width.value) { column -> block(Column(column + 1)) }
-    }
+    private fun onColumn(width: Width, block: (Column) -> Unit) =
+        repeat(width.value) { index -> block(Column(index + 1)) }
 }

--- a/src/main/kotlin/minesweeper/view/resource/StringResource.kt
+++ b/src/main/kotlin/minesweeper/view/resource/StringResource.kt
@@ -3,7 +3,8 @@ package minesweeper.view.resource
 import minesweeper.model.Cell
 
 fun getString(cell: Cell?): String = when (cell) {
-    null -> ""
     is Cell.Zero -> "C"
     is Cell.Mine -> "*"
+    is Cell.Number -> "${cell.adjustMineCount.value}"
+    null -> ""
 }

--- a/src/main/kotlin/minesweeper/view/resource/StringResource.kt
+++ b/src/main/kotlin/minesweeper/view/resource/StringResource.kt
@@ -3,7 +3,7 @@ package minesweeper.view.resource
 import minesweeper.model.Cell
 
 fun getString(cell: Cell?): String = when (cell) {
-    is Cell.Zero -> "C"
+    is Cell.Zero -> "0"
     is Cell.Mine -> "*"
     is Cell.Number -> "${cell.adjustMineCount.value}"
     null -> ""

--- a/src/main/kotlin/minesweeper/view/resource/StringResource.kt
+++ b/src/main/kotlin/minesweeper/view/resource/StringResource.kt
@@ -4,6 +4,6 @@ import minesweeper.model.Cell
 
 fun getString(cell: Cell?): String = when (cell) {
     null -> ""
-    is Cell.Blank -> "C"
+    is Cell.Zero -> "C"
     is Cell.Mine -> "*"
 }

--- a/src/main/kotlin/minesweeper/view/resource/StringResource.kt
+++ b/src/main/kotlin/minesweeper/view/resource/StringResource.kt
@@ -1,4 +1,4 @@
-package minesweeper.view.res
+package minesweeper.view.resource
 
 import minesweeper.model.Cell
 

--- a/src/test/kotlin/minesweeper/model/BoardTest.kt
+++ b/src/test/kotlin/minesweeper/model/BoardTest.kt
@@ -16,12 +16,6 @@ class BoardTest {
     }
 
     @Test
-    fun `보드는 MineCount를 가진다`() {
-        val board = Board(width = 2, height = 2, mineCount = 4)
-        assertThat(board.mineCount).isEqualTo(MineCount.valueOf(4))
-    }
-
-    @Test
     fun `Width나 Height이 0이면 보드는 비어있다`() {
         val board = Board(width = 0, height = 2)
         assertThat(board).isEqualTo(Board.EMPTY)

--- a/src/test/kotlin/minesweeper/model/BoardTest.kt
+++ b/src/test/kotlin/minesweeper/model/BoardTest.kt
@@ -33,4 +33,13 @@ class BoardTest {
         val board = Board(width = 10, height = 10)
         assertThat(board.cells[position]).isEqualTo(Cell.Blank(position))
     }
+
+    @Test
+    fun `Position의 Cell을 Mine으로 변환할 수 있다`() {
+        val position = Position(1, 1)
+        val board = Board(width = 1, height = 2)
+
+        val actual = board.mine(position)
+        assertThat(actual.cells[position]).isEqualTo(Cell.Mine(position))
+    }
 }

--- a/src/test/kotlin/minesweeper/model/BoardTest.kt
+++ b/src/test/kotlin/minesweeper/model/BoardTest.kt
@@ -22,7 +22,7 @@ class BoardTest {
     }
 
     @Test
-    fun `Width나 Height가 0이면 보드는 비어있다`() {
+    fun `Width나 Height이 0이면 보드는 비어있다`() {
         val board = Board(width = 0, height = 2)
         assertThat(board).isEqualTo(Board.EMPTY)
     }

--- a/src/test/kotlin/minesweeper/model/BoardTest.kt
+++ b/src/test/kotlin/minesweeper/model/BoardTest.kt
@@ -26,4 +26,11 @@ class BoardTest {
         val board = Board(width = 0, height = 2)
         assertThat(board).isEqualTo(Board.EMPTY)
     }
+
+    @Test
+    fun `Width * Height 크기의 비어있는 보드를 만들 수 있다`() {
+        val position = Position(10, 10)
+        val board = Board(width = 10, height = 10)
+        assertThat(board.cells[position]).isEqualTo(Cell.Blank(position))
+    }
 }

--- a/src/test/kotlin/minesweeper/model/BoardTest.kt
+++ b/src/test/kotlin/minesweeper/model/BoardTest.kt
@@ -42,4 +42,20 @@ class BoardTest {
         val actual = board.mine(position)
         assertThat(actual.cells[position]).isEqualTo(Cell.Mine(position))
     }
+
+    @Test
+    fun `Position의 Cell에 지뢰를 심으면 주변 Cell의 숫자가 증가한다`() {
+        val board = Board(width = 2, height = 2)
+        val actual = board.mine(Position(2, 2))
+        assertAll(
+            {
+                assertThat(actual.cells[Position(1, 1)])
+                    .isEqualTo(Cell.Number(MineCount.valueOf(1), Position(1, 1)))
+            },
+            {
+                assertThat(actual.cells[Position(1, 2)])
+                    .isEqualTo(Cell.Number(MineCount.valueOf(1), Position(1, 2)))
+            }
+        )
+    }
 }

--- a/src/test/kotlin/minesweeper/model/BoardTest.kt
+++ b/src/test/kotlin/minesweeper/model/BoardTest.kt
@@ -31,7 +31,7 @@ class BoardTest {
     fun `Width * Height 크기의 비어있는 보드를 만들 수 있다`() {
         val position = Position(10, 10)
         val board = Board(width = 10, height = 10)
-        assertThat(board.cells[position]).isEqualTo(Cell.Blank(position))
+        assertThat(board.cells[position]).isEqualTo(Cell.Zero(position))
     }
 
     @Test

--- a/src/test/kotlin/minesweeper/model/CellTest.kt
+++ b/src/test/kotlin/minesweeper/model/CellTest.kt
@@ -8,7 +8,7 @@ class CellTest {
 
     @Test
     fun `Cell은 Row와 Column을 가진다`() {
-        val cell = Cell.Blank(Row(1), Column(1))
+        val cell = Cell.Blank(Position(1, 1))
         assertAll(
             { assertThat(cell.row).isEqualTo(Row(1)) },
             { assertThat(cell.column).isEqualTo(Column(1)) }

--- a/src/test/kotlin/minesweeper/model/CellTest.kt
+++ b/src/test/kotlin/minesweeper/model/CellTest.kt
@@ -14,4 +14,10 @@ class CellTest {
             { assertThat(cell.column).isEqualTo(Column(1)) }
         )
     }
+
+    @Test
+    fun `Number Cell은 주변에 인접한 지뢰의 개수를 가진다`() {
+        val cell = Cell.Number(MineCount.valueOf(1), Position(1, 1))
+        assertThat(cell.adjustMineCount).isEqualTo(MineCount.valueOf(1))
+    }
 }

--- a/src/test/kotlin/minesweeper/model/CellTest.kt
+++ b/src/test/kotlin/minesweeper/model/CellTest.kt
@@ -20,4 +20,14 @@ class CellTest {
         val cell = Cell.Number(MineCount.valueOf(1), Position(1, 1))
         assertThat(cell.adjustMineCount).isEqualTo(MineCount.valueOf(1))
     }
+
+    @Test
+    fun `Number Cell의 인접한 지뢰 개수를 증가시킬 수 있다`() {
+        val cell = Cell.Number(MineCount.valueOf(1), Position(1, 1))
+        val actual = cell.increment()
+
+        assertThat(actual).isEqualTo(
+            Cell.Number(MineCount.valueOf(2), Position(1, 1))
+        )
+    }
 }

--- a/src/test/kotlin/minesweeper/model/CellTest.kt
+++ b/src/test/kotlin/minesweeper/model/CellTest.kt
@@ -8,7 +8,7 @@ class CellTest {
 
     @Test
     fun `Cell은 Row와 Column을 가진다`() {
-        val cell = Cell.Blank(Position(1, 1))
+        val cell = Cell.Zero(Position(1, 1))
         assertAll(
             { assertThat(cell.row).isEqualTo(Row(1)) },
             { assertThat(cell.column).isEqualTo(Column(1)) }

--- a/src/test/kotlin/minesweeper/model/CellsTest.kt
+++ b/src/test/kotlin/minesweeper/model/CellsTest.kt
@@ -45,7 +45,7 @@ class CellsTest {
             },
             {
                 assertThat(actual[Position(1, 2)])
-                    .isEqualTo(Cell.Blank(Position(1, 2)))
+                    .isEqualTo(Cell.Zero(Position(1, 2)))
             },
         )
     }

--- a/src/test/kotlin/minesweeper/model/CellsTest.kt
+++ b/src/test/kotlin/minesweeper/model/CellsTest.kt
@@ -28,4 +28,25 @@ class CellsTest {
             { assertThat(cells[1 to 10]).isNull() },
         )
     }
+
+    @Test
+    fun `Position의 Cell을 Mine으로 변환할 수 있다`() {
+        // given
+        val cells = Cells(1 to 1, 1 to 2)
+
+        // when
+        val actual = cells.mine(Position(1, 1))
+
+        // then
+        assertAll(
+            {
+                assertThat(actual[Position(1, 1)])
+                    .isEqualTo(Cell.Mine(Position(1, 1)))
+            },
+            {
+                assertThat(actual[Position(1, 2)])
+                    .isEqualTo(Cell.Blank(Position(1, 2)))
+            },
+        )
+    }
 }

--- a/src/test/kotlin/minesweeper/model/ColumnTest.kt
+++ b/src/test/kotlin/minesweeper/model/ColumnTest.kt
@@ -1,5 +1,7 @@
 package minesweeper.model
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -10,5 +12,23 @@ class ColumnTest {
     @ValueSource(ints = [0, -1, -100, -150])
     fun `열(Column)는 항상 1 이상의 값을 가진다`(value: Int) {
         assertThrows<RuntimeException> { Column(value) }
+    }
+
+    @Test
+    fun `Column(1)을 증가시키면 Column(2)가 된다`() {
+        val column = Column(1)
+        assertThat(column.increment()).isEqualTo(Column(2))
+    }
+
+    @Test
+    fun `Column(2)을 감소시키면 Column(1)이 된다`() {
+        val column = Column(2)
+        assertThat(column.decrement()).isEqualTo(Column(1))
+    }
+
+    @Test
+    fun `Column(1)을 감소시키면 Column(1)이 된다`() {
+        val column = Column(1)
+        assertThat(column.decrement()).isEqualTo(Column(1))
     }
 }

--- a/src/test/kotlin/minesweeper/model/FakeConstructor.kt
+++ b/src/test/kotlin/minesweeper/model/FakeConstructor.kt
@@ -1,9 +1,11 @@
 package minesweeper.model
 
+fun Board(width: Int, height: Int): Board = Board.create(Width.valueOf(width), Height.valueOf(height))
+
 fun Board(
     width: Int,
     height: Int,
-    mineCount: Int = 0
+    mineCount: Int
 ) = Board.shuffled(Width.valueOf(width), Height.valueOf(height), MineCount.valueOf(mineCount))
 
 fun Cells(vararg positions: Pair<Int, Int>): Cells = positions.map { (row, column) ->

--- a/src/test/kotlin/minesweeper/model/FakeConstructor.kt
+++ b/src/test/kotlin/minesweeper/model/FakeConstructor.kt
@@ -7,7 +7,7 @@ fun Board(
 ) = Board.shuffled(Width.valueOf(width), Height.valueOf(height), MineCount.valueOf(mineCount))
 
 fun Cells(vararg positions: Pair<Int, Int>): Cells = positions.map { (row, column) ->
-    Cell.Blank(Row(row), Column(column))
+    Cell.Blank(Position(row, column))
 }.let(::Cells)
 
 fun Position(row: Int, column: Int): Position = Position(Row(row), Column(column))

--- a/src/test/kotlin/minesweeper/model/FakeConstructor.kt
+++ b/src/test/kotlin/minesweeper/model/FakeConstructor.kt
@@ -9,7 +9,7 @@ fun Board(
 ) = Board.shuffled(Width.valueOf(width), Height.valueOf(height), MineCount.valueOf(mineCount))
 
 fun Cells(vararg positions: Pair<Int, Int>): Cells = positions.map { (row, column) ->
-    Cell.Blank(Position(row, column))
+    Cell.Zero(Position(row, column))
 }.let(::Cells)
 
 fun Position(row: Int, column: Int): Position = Position(Row(row), Column(column))

--- a/src/test/kotlin/minesweeper/model/FakeConstructor.kt
+++ b/src/test/kotlin/minesweeper/model/FakeConstructor.kt
@@ -6,7 +6,19 @@ fun Board(
     width: Int,
     height: Int,
     mineCount: Int
-) = Board.shuffled(Width.valueOf(width), Height.valueOf(height), MineCount.valueOf(mineCount))
+): Board {
+    val size = width * height
+    if (size == 0) return Board.EMPTY
+    val positions = Position.list(Width.valueOf(width), Height.valueOf(height)).shuffled()
+    val cells = positions.mapIndexed { index, position ->
+        if (index < mineCount) {
+            Cell.Mine(position)
+        } else {
+            Cell.Zero(position)
+        }
+    }
+    return Board(Cells(cells))
+}
 
 fun Cells(vararg positions: Pair<Int, Int>): Cells = positions.map { (row, column) ->
     Cell.Zero(Position(row, column))

--- a/src/test/kotlin/minesweeper/model/HeightTest.kt
+++ b/src/test/kotlin/minesweeper/model/HeightTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 class HeightTest {
 
     @Test
-    fun `Height은 0보다 작을 수 없다`() {
+    fun `Height은 0보다 작으면 항상 0이 된다`() {
         assertThat(Height.valueOf(-1)).isEqualTo(Height.ZERO)
     }
 }

--- a/src/test/kotlin/minesweeper/model/MineCountTest.kt
+++ b/src/test/kotlin/minesweeper/model/MineCountTest.kt
@@ -1,6 +1,7 @@
 package minesweeper.model
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -10,5 +11,12 @@ class MineCountTest {
     @ValueSource(ints = [-1, -100, -150])
     fun `지뢰 개수가 0보다 작으면 항상 0개가 된다`(count: Int) {
         assertThat(MineCount.valueOf(count)).isEqualTo(MineCount.ZERO)
+    }
+
+    @Test
+    fun `지뢰 개수가 가지는 값 하나를 증가 시킬 수 있다`() {
+        val mineCount = MineCount.ZERO
+        val actual = mineCount.increment()
+        assertThat(actual).isEqualTo(MineCount.valueOf(1))
     }
 }

--- a/src/test/kotlin/minesweeper/model/MineCountTest.kt
+++ b/src/test/kotlin/minesweeper/model/MineCountTest.kt
@@ -8,7 +8,7 @@ class MineCountTest {
 
     @ParameterizedTest
     @ValueSource(ints = [-1, -100, -150])
-    fun `지뢰 개수는 0보다 작을 수 없다`(count: Int) {
+    fun `지뢰 개수가 0보다 작으면 항상 0개가 된다`(count: Int) {
         assertThat(MineCount.valueOf(count)).isEqualTo(MineCount.ZERO)
     }
 }

--- a/src/test/kotlin/minesweeper/model/PositionTest.kt
+++ b/src/test/kotlin/minesweeper/model/PositionTest.kt
@@ -1,17 +1,38 @@
 package minesweeper.model
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 
 class PositionTest {
 
+    private lateinit var position: Position
+
+    @BeforeEach
+    fun setup() {
+        position = Position(2, 2)
+    }
+
     @Test
     fun `Position은 Row와 Column을 가진다`() {
-        val position = Position(2, 5)
         assertAll(
             { assertThat(position.row).isEqualTo(Row(2)) },
-            { assertThat(position.column).isEqualTo(Column(5)) }
+            { assertThat(position.column).isEqualTo(Column(2)) }
+        )
+    }
+
+    @Test
+    fun `Position의 위치 이동 기능 테스트`() {
+        assertAll(
+            { assertThat(position.topLeft()).isEqualTo(Position(1, 1)) },
+            { assertThat(position.top()).isEqualTo(Position(1, 2)) },
+            { assertThat(position.topRight()).isEqualTo(Position(1, 3)) },
+            { assertThat(position.left()).isEqualTo(Position(2, 1)) },
+            { assertThat(position.right()).isEqualTo(Position(2, 3)) },
+            { assertThat(position.bottomLeft()).isEqualTo(Position(3, 1)) },
+            { assertThat(position.bottom()).isEqualTo(Position(3, 2)) },
+            { assertThat(position.bottomRight()).isEqualTo(Position(3, 3)) },
         )
     }
 }

--- a/src/test/kotlin/minesweeper/model/RowTest.kt
+++ b/src/test/kotlin/minesweeper/model/RowTest.kt
@@ -1,5 +1,7 @@
 package minesweeper.model
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -10,5 +12,23 @@ class RowTest {
     @ValueSource(ints = [0, -1, -100, -150])
     fun `행(Row)는 항상 1 이상의 값을 가진다`(value: Int) {
         assertThrows<RuntimeException> { Row(value) }
+    }
+
+    @Test
+    fun `Row(1)를 증가시키면 Row(2)가 된다`() {
+        val row = Row(1)
+        assertThat(row.increment()).isEqualTo(Row(2))
+    }
+
+    @Test
+    fun `Row(2)를 감소시키면 Row(1)이 된다`() {
+        val row = Row(2)
+        assertThat(row.decrement()).isEqualTo(Row(1))
+    }
+
+    @Test
+    fun `Row(1)를 감소시키면 Row(1)이 된다`() {
+        val row = Row(1)
+        assertThat(row.decrement()).isEqualTo(Row(1))
     }
 }

--- a/src/test/kotlin/minesweeper/model/WidthTest.kt
+++ b/src/test/kotlin/minesweeper/model/WidthTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 class WidthTest {
 
     @Test
-    fun `Width는 0보다 작을 수 없다`() {
+    fun `Width는 0보다 작으면 항상 0이 된다`() {
         assertThat(Width.valueOf(-1)).isEqualTo(Width.ZERO)
     }
 }


### PR DESCRIPTION
1단계 피드백 반영
- 82ccace4aeeb9df6facfe8b31a0a77e8aec268b1

### 고찰
- 블랙잭에서도 모든 상태는 Controller에서만 변화할 수 있도록 모델에서는 항상 불변을 유지하는 방향으로 구현을 해 보고 있습니다.
- 그러다보니 콜백과 다소 복잡한 코드가 따라오는 트레이드 오프가 있기는 한데 반대로 다시 Stateful한 모델을 작성할려고 하면 오히려 Stateless보다 더 불편한(?) 느낌이 드네요 ㅎㅎ;;

### 고민거리
- 다른 리뷰어님과 같이 의논하면서 생각을 정리했었는데 아래 상황에 대한 의견이 궁금합니다.

Parent 라는 추상 클래스가 있고. 각 구현체에 foo()라는 행동을 수행하기 인터페이스를 가진다.
구현체가 A, B, C 세 개라고 헀을 때 A는 아무런 동작을 하지 않고 자기 자신을 반환하고, B는 값을 1 증가시킨 자신을 반환하고 C는 오류가 발생한다.

이 foo()라는 메소드는 Parent의 인터페이스가 아닌 B의 멤버 함수로 존재해야 하는게 아닐까? 라는 의문입니다.
그렇다면 외부에서 이 함수를 호출할 때에는 항상 캐스팅을 하고서 사용해야 하는 불편함과 정적 타입에서 알아서 처리할 거라는 믿음을 가지고 메시지를 전달...

제가 작성한 코드로 예를 들어보면
``` kotlin
sealed class Cell {
    abstract fun increment(): Cell


    class Number(val count :Int): Cell() {
        override fun increment(): Cell = Cell(count + 1)
    }

    class Mine: Cell() {
        override fun increment(): Cell = this // 값을 증가시키는 함수는 아무런 동작을 하지 않음
    }
}

// Usage (1) increment() 함수가 Cell에 있음
val cell: Cell
return cell.increment()

// Usage (2) increment() 함수가 Number에 있음
val cell: Cell
if (cell is Cell.Number) {
    return cell.increment()
} else {
    return this
}

```

위의 C 케이스처럼 오류를 던지는건 프로그램 전체에 영향을 줄 수 있기 때문에 지양하는 것으로 보이는데 this를 반환한다는 의미 자체가 동작을 하지 않는다와 같다고 가정할 수 있어서 조금 헷갈리네요